### PR TITLE
Install libopenblas-dev in python container to support latest numpy.

### DIFF
--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -1,6 +1,8 @@
 FROM icr.io/ibmz/python:3.9.13
-RUN apt-get update && \
-    apt-get clean
+RUN apt-get update \
+    && apt-get install -y \
+        libopenblas-dev \
+    && apt-get clean
 RUN pip3 install numpy
 ENTRYPOINT [ "python3" ]
 CMD [ "--help" ]


### PR DESCRIPTION
Install libopenblas-dev in python container to support latest numpy. (#13)	905ab9f	Charles Volzka <42243335+cjvolzka@users.noreply.github.com>	Oct 6, 2023 at 1:09 PM
