### PR TITLE
Update Python example image

### DIFF
--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -1,4 +1,4 @@
-FROM icr.io/ibmz/python:3.9.13
+FROM icr.io/ibmz/python:3.9.16-bullseye
 RUN apt-get update \
     && apt-get install -y \
         libopenblas-dev \


### PR DESCRIPTION
Switch Python example image tag from `3.9.13` to `3.9.16-bullseye` as the old image was removed from ICR