### PR TITLE
[Cherry-pick] Update Python example image (#22)

### DIFF
--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -1,4 +1,4 @@
-FROM icr.io/ibmz/python:3.9.13
+FROM icr.io/ibmz/python:3.9.16-bullseye
 RUN apt-get update \
     && apt-get install -y \
         libopenblas-dev \


### PR DESCRIPTION
Switch Python example image tag from `3.9.13` to `3.9.16-bullseye` as the old image was removed from ICR

Signed-off-by: Charles Volzka <cjvolzka@us.ibm.com>
(cherry picked from commit e939e92d3eff1f13017da6d05262da8caaa38a1c)